### PR TITLE
tests: make the tests pass with gcc-9

### DIFF
--- a/tests/CFG_loop/Makefile
+++ b/tests/CFG_loop/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,9 +2,18 @@ cmake_minimum_required (VERSION 2.6)
 project (handler_plug)
 enable_testing()
 
+# -fdiagnostics-show-line-numbers is enabled by default in gcc-9
+# we need to disable it (if the flag exists) to make the tests pass
+set(HOST_CFLAGS)
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-fno-diagnostics-show-line-numbers HAVE_NO_NL)
+if(HAVE_NO_NL)
+    set(HOST_CFLAGS -fno-diagnostics-show-line-numbers)
+endif()
+
 macro(add_test_wrap test_name)
     add_test("${test_name}" bash -o pipefail -c
-        "LC_ALL=C CCACHE_DISABLE=1 MALLOC_PERTURB_=170 export testdir=${test_name} && sh ./runtest.sh")
+        "LC_ALL=C CCACHE_DISABLE=1 MALLOC_PERTURB_=170 testdir='${test_name}' HOST_CFLAGS='${HOST_CFLAGS}' sh ./runtest.sh")
 endmacro()
 
 if("${CMAKE_CXX_COMPILER}" MATCHES ".*NOTFOUND")

--- a/tests/attribute_cleanup/Makefile
+++ b/tests/attribute_cleanup/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/changed_errno/Makefile
+++ b/tests/changed_errno/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/cswrap/Makefile
+++ b/tests/cswrap/Makefile
@@ -1,2 +1,2 @@
 check:
-	gcc -c -pthread ./cswrap.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c -pthread ./cswrap.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/destroy_stored_errno/Makefile
+++ b/tests/destroy_stored_errno/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/ok_example/Makefile
+++ b/tests/ok_example/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/own_exit/Makefile
+++ b/tests/own_exit/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/restore_and_change/Makefile
+++ b/tests/restore_and_change/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/sig_bash/Makefile
+++ b/tests/sig_bash/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c -g -O4 -Wno-parentheses -Wno-format-security -finline-functions -findirect-inlining ./sig.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err 
+	gcc -c -g -O4 -Wno-parentheses -Wno-format-security -finline-functions -findirect-inlining ./sig.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err 

--- a/tests/sigaction_and_staticVar/Makefile
+++ b/tests/sigaction_and_staticVar/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err

--- a/tests/sigbus_systemd/Makefile
+++ b/tests/sigbus_systemd/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./sigbus.c -o /dev/null -fplugin=./../../csigsafe.so 2>test.err
+	gcc -c ./sigbus.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>test.err

--- a/tests/signal_and_wrapper/Makefile
+++ b/tests/signal_and_wrapper/Makefile
@@ -1,2 +1,2 @@
 test:
-	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so 2>./test.err
+	gcc -c ./test.c -o /dev/null -fplugin=./../../csigsafe.so $(HOST_CFLAGS) 2>./test.err


### PR DESCRIPTION
... where `-fdiagnostics-show-line-numbers` is enabled by default